### PR TITLE
Feat: UX improvements

### DIFF
--- a/agent/Cargo-dev.lock
+++ b/agent/Cargo-dev.lock
@@ -2251,7 +2251,7 @@ dependencies = [
 
 [[package]]
 name = "webscp-agent"
-version = "0.1.4"
+version = "0.2.1"
 dependencies = [
  "flate2",
  "json",

--- a/agent/Cargo-dev.toml
+++ b/agent/Cargo-dev.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webscp-agent"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Marcell Fülöp <marekful@domainloop.net>"]
 repository = "https://github.com/marekful/webscp/agent"
 edition = "2021"

--- a/agent/Cargo.lock
+++ b/agent/Cargo.lock
@@ -1958,7 +1958,7 @@ dependencies = [
 
 [[package]]
 name = "webscp-agent"
-version = "0.1.4"
+version = "0.2.1"
 dependencies = [
  "flate2",
  "json",

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webscp-agent"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Marcell Fülöp <marekful@domainloop.net>"]
 repository = "https://github.com/marekful/webscp/agent"
 edition = "2021"

--- a/agent/src/cli/client.rs
+++ b/agent/src/cli/client.rs
@@ -4,7 +4,7 @@ use std::{
     fs,
     fs::OpenOptions,
     io::{prelude::*, Error},
-    net::TcpStream,
+    net::{TcpStream, ToSocketAddrs},
     os::unix::fs::OpenOptionsExt,
     path::Path,
     process::exit,
@@ -17,6 +17,7 @@ use tokio::{
 };
 
 use std::process::Stdio;
+use std::time::Duration;
 
 use sha256::digest;
 
@@ -28,6 +29,7 @@ use crate::{
     },
     files_api::{FilesApi, Transfer},
 };
+use crate::files_api::RequestError;
 
 #[derive(Debug)]
 pub struct Client<'r> {
@@ -48,6 +50,17 @@ impl From<Error> for ClientError {
             code: 987,
             message: err.to_string(),
             http_code: Some(500),
+        }
+    }
+}
+
+impl From<RequestError> for ClientError {
+    fn from(err: RequestError) -> Self {
+        let http_code = err.http_code.unwrap_or(500).to_string().parse::<i32>().unwrap();
+        ClientError {
+            code: err.code,
+            message: err.message,
+            http_code: Some(http_code)
         }
     }
 }
@@ -347,8 +360,23 @@ impl Client<'_> {
     }
 
     fn create_session(&self, secret: Option<&str>) -> Option<Session> {
-        // create ssh connection
-        let tcp = match TcpStream::connect(self.host.to_owned() + ":" + &*self.port.to_string()) {
+        // setup tcp connection
+        let timeout = Duration::from_secs(10);
+        let addr_str = format!("{}:{}", self.host, self.port);
+        let mut addrs_iter = addr_str.to_socket_addrs().unwrap();
+        let socket_addr = match addrs_iter.next() {
+            Some(sa) => sa,
+            None => {
+                Self::print_error_and_exit(
+                    136,
+                    format!("503 Couldn't connect to {}:{}", self.host, self.port),
+                );
+                return None;
+            }
+        };
+
+        // create tcp connection
+        let tcp = match TcpStream::connect_timeout(&socket_addr, timeout) {
             Ok(tcp) => tcp,
             Err(e) => {
                 Self::print_error_and_exit(
@@ -358,6 +386,8 @@ impl Client<'_> {
                 return None;
             }
         };
+
+        // create ssh session over the tcp connection
         let mut sess = Session::new().unwrap();
         sess.set_tcp_stream(tcp);
         sess.handshake().unwrap();

--- a/agent/src/cli/client.rs
+++ b/agent/src/cli/client.rs
@@ -16,8 +16,7 @@ use tokio::{
     process::Command,
 };
 
-use std::process::Stdio;
-use std::time::Duration;
+use std::{process::Stdio, time::Duration};
 
 use sha256::digest;
 
@@ -27,9 +26,8 @@ use crate::{
         COMMAND_GET_LOCAL_RESOURCE, COMMAND_GET_LOCAL_USER, COMMAND_GET_LOCAL_VERSION,
         COMMAND_LOCAL_BEFORE_COPY, DEFAULTS,
     },
-    files_api::{FilesApi, Transfer},
+    files_api::{FilesApi, RequestError, Transfer},
 };
-use crate::files_api::RequestError;
 
 #[derive(Debug)]
 pub struct Client<'r> {
@@ -56,11 +54,16 @@ impl From<Error> for ClientError {
 
 impl From<RequestError> for ClientError {
     fn from(err: RequestError) -> Self {
-        let http_code = err.http_code.unwrap_or(500).to_string().parse::<i32>().unwrap();
+        let http_code = err
+            .http_code
+            .unwrap_or(500)
+            .to_string()
+            .parse::<i32>()
+            .unwrap();
         ClientError {
             code: err.code,
             message: err.message,
-            http_code: Some(http_code)
+            http_code: Some(http_code),
         }
     }
 }

--- a/agent/src/files_api.rs
+++ b/agent/src/files_api.rs
@@ -343,7 +343,7 @@ impl FilesApi {
                     code: 191,
                     message: e.message,
                     http_code: Some(500),
-                })
+                });
             }
         };
 

--- a/frontend/src/api/utils.js
+++ b/frontend/src/api/utils.js
@@ -33,7 +33,7 @@ export async function fetchURL(url, opts, auth = true) {
     const error = new Error(await res.text());
     error.status = res.status;
 
-    if (auth && res.status == 401) {
+    if (auth && res.status === 401) {
       logout();
     }
 

--- a/frontend/src/components/StatefulButton.vue
+++ b/frontend/src/components/StatefulButton.vue
@@ -1,0 +1,101 @@
+<template>
+  <button
+    ref="button"
+    @click="handle"
+    :type="type"
+    :class="className"
+    :aria-label="$t(labelTr)"
+    :title="$t(titleTr)"
+  >
+    <i v-if="loading" class="material-icons spin">data_usage</i
+    >{{ $t(labelTr) }}
+  </button>
+</template>
+
+<script>
+export default {
+  name: "stateful-button",
+  props: {
+    type: {
+      type: String,
+      default: "button",
+      validator: (value) => ["button", "submit"].includes(value),
+    },
+    handler: {
+      type: Function,
+      default: () => {},
+    },
+    waitHandler: {
+      type: Boolean,
+      default: true,
+    },
+    className: {
+      type: String,
+      default: "button button--flat",
+    },
+    labelTr: {
+      type: String,
+      default: "",
+    },
+    titleTr: {
+      type: String,
+      default: "",
+    },
+  },
+  data: function () {
+    return {
+      loading: false,
+    };
+  },
+  methods: {
+    async handle(event) {
+      if (this.loading) return;
+
+      const form = event.target && event.target.form ? event.target.form : null;
+      if (form) {
+        if (!form.reportValidity()) {
+          return;
+        }
+        if (!this.handler) {
+          form.requestSubmit();
+        }
+      }
+
+      this.loading = true;
+      this.$refs.button.setAttribute("disabled", "disabled");
+      this.$refs.button.classList.add("loading");
+
+      if (this.handler) {
+        if (this.waitHandler) {
+          await this.handler(event);
+        } else {
+          this.handler(event);
+        }
+      }
+
+      if (this.$refs.button) {
+        this.$refs.button.removeAttribute("disabled");
+        this.$refs.button.classList.remove("loading");
+      }
+      this.loading = false;
+    },
+  },
+};
+</script>
+
+<style scoped>
+button i,
+input i {
+  font-size: 100%;
+  vertical-align: bottom;
+  margin-right: 0.5em;
+  line-height: 1.2em;
+}
+
+button.loading,
+input.loading {
+  opacity: 0.66;
+  cursor: not-allowed;
+  background-color: var(--distinct-background);
+}
+</style>

--- a/frontend/src/components/prompts/Transfers.vue
+++ b/frontend/src/components/prompts/Transfers.vue
@@ -368,6 +368,7 @@ export default {
   color: var(--dark-red);
   font-size: small;
   margin: 0.25em 0 0.75em 0;
+  line-break: anywhere;
 }
 
 .transfer .stats {

--- a/frontend/src/components/settings/AgentForm.vue
+++ b/frontend/src/components/settings/AgentForm.vue
@@ -1,9 +1,8 @@
 <template>
   <div class="agent-form">
-    <p>
+    <p v-if="!isNew">
       <label for="name">{{ $t("settings.agent.connectionName") }}</label>
       <input
-        v-if="!isNew"
         class="input input--block"
         type="text"
         v-model="agent.branding"

--- a/frontend/src/store/getters.js
+++ b/frontend/src/store/getters.js
@@ -22,7 +22,7 @@ const getters = {
     return total;
   },
   progress: (state) => {
-    if (state.upload.progress.length == 0) {
+    if (state.upload.progress.length === 0) {
       return 0;
     }
 

--- a/frontend/src/utils/buttons.js
+++ b/frontend/src/utils/buttons.js
@@ -29,7 +29,7 @@ function loadingPromise(button) {
       return;
     }
 
-    if (el.innerHTML == "autorenew" || el.innerHTML == "done") {
+    if (el.innerHTML === "autorenew" || el.innerHTML === "done") {
       return;
     }
 

--- a/frontend/src/utils/transfers.js
+++ b/frontend/src/utils/transfers.js
@@ -271,12 +271,14 @@ function handleMessage($store) {
           stats = getStats(extra);
         }
         if (data === "archived") {
+          cancelable = false;
           icon = "folder_zip";
           message = "archiving";
           messageTr = "archiving";
           stats = getArchiveStats(extra);
         }
         if (data === "compressed") {
+          cancelable = false;
           icon = "folder_zip";
           message = "compressing";
           messageTr = "compressing";

--- a/frontend/src/utils/transfers.js
+++ b/frontend/src/utils/transfers.js
@@ -216,6 +216,8 @@ function handleMessage($store) {
   return function (event) {
     if (!event.isTrusted) return;
 
+    const transfers = $store.state.transfers;
+
     let icon,
       data,
       message,
@@ -299,6 +301,13 @@ function handleMessage($store) {
         errorMessage = i18n.te(`transfer.${messageTr}`)
           ? i18n.t(`transfer.${messageTr}`)
           : message;
+
+        for (let tr of transfers) {
+          if (event.target.transferID === tr.transferID) {
+            tr.sseClient && tr.sseClient.close();
+            break;
+          }
+        }
 
         update($store, {
           transferID: event.target.transferID,

--- a/frontend/src/views/settings/Agent.vue
+++ b/frontend/src/views/settings/Agent.vue
@@ -2,7 +2,7 @@
   <errors v-if="error" :errorCode="error.status" />
   <div class="row" v-else-if="!loading">
     <div class="column">
-      <form @submit="save" class="card">
+      <form ref="form" class="card">
         <div class="card-title">
           <h2 v-if="agent.id === 0">
             {{ $t("settings.agent.newConnection") }}
@@ -35,12 +35,13 @@
           >
             {{ $t("buttons.save") }}
           </button>
-          <input
+          <stateful-button
             v-if="isNew"
-            class="button button--flat"
-            type="submit"
-            :value="$t('buttons.connectAndSave')"
-          />
+            :handler="save"
+            class-name="button button--flat"
+            label-tr="buttons.connectAndSave"
+            title-tr="buttons.connectAndSave"
+          ></stateful-button>
         </div>
       </form>
     </div>
@@ -72,11 +73,13 @@
 import { mapState, mapMutations } from "vuex";
 import { agents as api } from "@/api";
 import AgentForm from "@/components/settings/AgentForm";
+import StatefulButton from "@/components/StatefulButton";
 import Errors from "@/views/Errors";
 
 export default {
   name: "agent",
   components: {
+    StatefulButton,
     AgentForm,
     Errors,
   },
@@ -158,7 +161,6 @@ export default {
           this.$showSuccess(this.$t("settings.agent.connectionUpdated"));
         }
       } catch (e) {
-        console.log("err> ", e);
         this.$showError(e);
       }
     },


### PR DESCRIPTION
# UX improvements

## feat(frontend): add stateful-button component (https://github.com/marekful/webscp/pull/42/commits/d6714ad5c2f478e0c824496b4378b0e712c75509) 

* the statful-button component is a generalized button that
  differentiates between 'default' and 'loading' states;
  disabling itself and showing an animation while loading
* replace 'connect & save' to stateful-button on the new
  agent connection form
* replace 'copy' to stateful-button in the Copy dialogue
* replace 'move' to stateful-button in the Move dialogue

## feature(agent): add timeout to tcp connection open (https://github.com/marekful/webscp/pull/42/commits/a6f55790179da4473783fa01663c97c4f93274d9) 

* add timeout to connection attempts to avoid hanging too long, e.g. on
  a firewall drop rule
* + clean up some unnecessary code
* + add code comments

## fix(frontend): fix 'cancelable' flag state for archiving/compressing (https://github.com/marekful/webscp/pull/42/commits/737961065a9b1fbbd226e5eae0aa68f1e0a51767)

## fix(frontend): ensure 'sseClient' is immediately closed on error (https://github.com/marekful/webscp/pull/42/commits/55005423f420525afb95d872a58cb8121ee7615c)